### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ cd /data/final/
 
 for z in $(seq 8 19);
 do
-  azcopy copy --recursive z "https://{myaccount}.blob.core.windows.net/{mycontainer}?{my-sas-token}"
+  azcopy copy --recursive $z "https://{myaccount}.blob.core.windows.net/{mycontainer}?{my-sas-token}"
 done
 ```
 


### PR DESCRIPTION
These updates reflect recent changes in MML imagery data formats and should make it easier for someone to follow the instructions without extensive knowledge about generating tiles from aerial imagery while working on an Azure VM.

- Add notes on MML Imagery coming in GeoTIFF format
- Fix some console commands to better work in Azure VMs